### PR TITLE
Make parts lists more ergonomic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 on:
   workflow_dispatch:
   workflow_call:
+  pull_request:
 
 jobs:
   test-windows:

--- a/src/pstack/gui/controls.cpp
+++ b/src/pstack/gui/controls.cpp
@@ -54,17 +54,23 @@ void controls::initialize(main_window* parent) {
         minimize_text = new wxStaticText(panel, wxID_ANY, "Minimize box:");
         quantity_spinner = new wxSpinCtrl(panel);
         quantity_spinner->SetRange(0, 200);
+        quantity_spinner->Disable();
         min_hole_spinner = new wxSpinCtrl(panel);
         min_hole_spinner->SetRange(0, 100);
+        min_hole_spinner->Disable();
         minimize_checkbox = new wxCheckBox(panel, wxID_ANY, "");
+        minimize_checkbox->Disable();
         wxArrayString rotation_choices;
         rotation_choices.Add("None");
         rotation_choices.Add("Cubic");
         rotation_choices.Add("Arbitrary");
         rotation_text = new wxStaticText(panel, wxID_ANY, "Rotations:");
         rotation_dropdown = new wxChoice(panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, rotation_choices);
+        rotation_dropdown->Disable();
         preview_voxelization_button = new wxButton(panel, wxID_ANY, "Preview voxelization");
+        preview_voxelization_button->Disable();
         preview_bounding_box_button = new wxButton(panel, wxID_ANY, "Preview bounding box");
+        preview_bounding_box_button->Disable();
     }
 
     {

--- a/src/pstack/gui/controls.cpp
+++ b/src/pstack/gui/controls.cpp
@@ -58,7 +58,7 @@ void controls::initialize(main_window* parent) {
         min_hole_spinner = new wxSpinCtrl(panel);
         min_hole_spinner->SetRange(0, 100);
         min_hole_spinner->Disable();
-        minimize_checkbox = new wxCheckBox(panel, wxID_ANY, "");
+        minimize_checkbox = new wxCheckBox(panel, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
         minimize_checkbox->Disable();
         wxArrayString rotation_choices;
         rotation_choices.Add("None");

--- a/src/pstack/gui/main_window.cpp
+++ b/src/pstack/gui/main_window.cpp
@@ -328,7 +328,7 @@ wxMenuBar* main_window::make_menu_bar() {
 
     auto preferences_menu = new wxMenu();
     preferences_menu->AppendCheckItem((int)menu_item::pref_scroll, "Invert &scroll", "Change the viewport scroll direction");
-    preferences_menu->AppendCheckItem((int)menu_item::pref_extra, "Display &extra parts", "Display the extra part quantity separately");
+    preferences_menu->AppendCheckItem((int)menu_item::pref_extra, "Display &extra parts", "Display the quantity of extra parts separately");
     menu_bar->Append(preferences_menu, "&Preferences");
 
     auto help_menu = new wxMenu();

--- a/src/pstack/gui/main_window.cpp
+++ b/src/pstack/gui/main_window.cpp
@@ -59,7 +59,7 @@ void main_window::on_select_parts(const std::vector<std::size_t>& indices) {
 void main_window::set_part(const std::size_t index) {
     enable_part_settings(true);
     _current_parts.clear();
-    _current_parts.emplace_back(_parts_list.at(index).get(), index);
+    _current_parts.emplace_back(&_parts_list.at(index), index);
     _controls.quantity_spinner->SetValue(_current_parts[0].part->quantity);
     _controls.min_hole_spinner->SetValue(_current_parts[0].part->min_hole);
     _controls.minimize_checkbox->SetValue(_current_parts[0].part->rotate_min_box);
@@ -448,7 +448,7 @@ void main_window::on_import_part(wxCommandEvent& event) {
     }
     _parts_list.update_label();
     if (paths.size() == 1) {
-        const calc::part& part = *_parts_list.at(_parts_list.rows() - 1);
+        const calc::part& part = _parts_list.at(_parts_list.rows() - 1);
         _viewport->set_mesh(part.mesh, part.centroid);
     }
 

--- a/src/pstack/gui/main_window.cpp
+++ b/src/pstack/gui/main_window.cpp
@@ -27,7 +27,6 @@ main_window::main_window(const wxString& title)
     _parts_list.initialize(_controls.notebook_panels[0]);
     _results_list.initialize(_controls.notebook_panels[2]);
     bind_all_controls();
-    enable_part_settings(false);
 
     wxGLAttributes attrs;
     attrs.PlatformDefaults().Defaults().EndList();

--- a/src/pstack/gui/main_window.hpp
+++ b/src/pstack/gui/main_window.hpp
@@ -33,8 +33,11 @@ private:
     void set_part(std::size_t index);
     void unset_part();
     parts_list _parts_list{};
-    std::shared_ptr<calc::part> _current_part = nullptr;
-    std::optional<std::size_t> _current_part_index = std::nullopt;
+    struct _current_part_t {
+        calc::part* part;
+        std::size_t index;
+    };
+    std::vector<_current_part_t> _current_parts{};
     void enable_part_settings(bool enable);
 
     void on_select_results(const std::vector<std::size_t>& indices);

--- a/src/pstack/gui/main_window.hpp
+++ b/src/pstack/gui/main_window.hpp
@@ -30,8 +30,6 @@ private:
     preferences _preferences;
 
     void on_select_parts(const std::vector<std::size_t>& indices);
-    void set_part(std::size_t index);
-    void unset_part();
     parts_list _parts_list{};
     struct _current_part_t {
         calc::part* part;

--- a/src/pstack/gui/parts_list.cpp
+++ b/src/pstack/gui/parts_list.cpp
@@ -48,13 +48,21 @@ calc::part make_part(std::string mesh_file, bool mirrored) {
 }
 
 wxString quantity_string(const calc::part& part, const bool show_extra) {
-    if (show_extra and part.base_quantity.has_value()) {
-        const int diff = part.quantity - *part.base_quantity;
-        if (diff > 0) {
-            return wxString::Format("%d + %d", *part.base_quantity, diff);
-        }
+    if (not part.base_quantity.has_value()) {
+        return wxString::Format("%d", part.quantity);
     }
-    return wxString::Format("%d", part.quantity);
+
+    static const wxString up_arrow = wxString::FromUTF8(" \xe2\x86\x91"); // ↑
+    static const wxString down_arrow = wxString::FromUTF8(" \xe2\x86\x93"); // ↓
+    static const wxString empty = "";
+
+    const int diff = part.quantity - *part.base_quantity;
+    if (diff > 0 and show_extra) {
+        return wxString::Format("%d + %d%s", *part.base_quantity, diff, up_arrow);
+    } else {
+        auto& arrow_suffix = (diff > 0) ? up_arrow : (diff < 0) ? down_arrow : empty;
+        return wxString::Format("%d%s", part.quantity, arrow_suffix);
+    }
 }
 
 } // namespace

--- a/src/pstack/gui/parts_list.hpp
+++ b/src/pstack/gui/parts_list.hpp
@@ -28,8 +28,8 @@ public:
     void reload_quantity(std::size_t row);
     void delete_all();
     void delete_selected();
-    std::shared_ptr<calc::part> at(std::size_t row) {
-        return _parts.at(row);
+    calc::part& at(std::size_t row) {
+        return *_parts.at(row);
     }
     std::vector<std::shared_ptr<const calc::part>> get_all() const;
 


### PR DESCRIPTION
Closes #25 
* Batch editing works as one would expect
* If all the selected parts have the same value for a specific widget, that value is shown, otherwise the widget value is left empty
* The part displayed in the viewport is whichever of the parts was selected first of the currently selected batch

Closes #27 
* This only applies if a part has a "base quantity", i.e. a default quantity parsed from the file name
* If the quantity is higher than the base quantity, an up arrow "↑" is displayed
* If the quantity is lower than the base quantity, a down arrow "↓" is displayed
